### PR TITLE
Dmem MemPerf testing

### DIFF
--- a/chipyard/RadianceConfigs.scala
+++ b/chipyard/RadianceConfigs.scala
@@ -217,5 +217,6 @@ class RadianceMemPerfConfig extends Config(
   new WithMemPerfMuonTileReplacement(InCluster(0)) ++
   new WithMuonCores(1, location = InCluster(0), l0i = Some(L0iCacheConfig), l0d = Some(L0dCacheConfig)) ++
   new WithRadianceCluster(0, smemConfig = TapeoutSmemConfig, l1Config = L1CacheConfig) ++
+  new WithExtGPUMem() ++
   new RadianceBaseConfig
 )

--- a/chipyard/RadianceConfigs.scala
+++ b/chipyard/RadianceConfigs.scala
@@ -48,7 +48,7 @@ object L0iCacheConfig extends DCacheParams(
   nWays = 1,
   rowBits = 32 * 8,
   blockBytes = 32,
-  nMSHRs = 8,
+  nMSHRs = 2,
 )
 
 object L0dCacheConfig extends DCacheParams(
@@ -56,7 +56,7 @@ object L0dCacheConfig extends DCacheParams(
   nWays = 1,
   rowBits = 64 * 8,
   blockBytes = 64,
-  nMSHRs = 8,
+  nMSHRs = 4,
 )
 
 object L1CacheConfig extends DCacheParams(
@@ -64,7 +64,7 @@ object L1CacheConfig extends DCacheParams(
   nWays = 4,
   rowBits = 32 * 8, // physical (sram) size
   blockBytes = 32, // logical size
-  nMSHRs = 8,
+  nMSHRs = 8, // maybe be able to decrease this
 )
 
 class WithRadianceControlBus extends Config ((site, here, up) => {
@@ -215,7 +215,7 @@ class RadianceClusterConfig extends Config(
 
 class RadianceMemPerfConfig extends Config(
   new WithMemPerfMuonTileReplacement(InCluster(0)) ++
-  new WithMuonCores(1, location = InCluster(0), l0i = Some(L0iCacheConfig), l0d = Some(L0dCacheConfig)) ++
+  new WithMuonCores(1, location = InCluster(0), l0i = Some(L0iCacheConfig), l0d = Some(L0dCacheConfig)) ++ // try: set to 2 (from 1)
   new WithRadianceCluster(0, smemConfig = TapeoutSmemConfig, l1Config = L1CacheConfig) ++
   new WithExtGPUMem() ++
   new RadianceBaseConfig

--- a/src/main/scala/radiance/muon/MuonCore.scala
+++ b/src/main/scala/radiance/muon/MuonCore.scala
@@ -75,8 +75,7 @@ case class MuonCoreParams(
   def l1ReqTagBits: Int = {
     val instVsData = 1
     val coreBits = log2Ceil(numCores)
-    println("l1 tag bits", instVsData + coreBits + 6) // max(log2Ceil(nMSHRs + nMMIOs) for i, d)
-    instVsData + coreBits + 6
+    instVsData + coreBits + 5
   }
 }
 

--- a/src/main/scala/radiance/unittest/MemPerf.scala
+++ b/src/main/scala/radiance/unittest/MemPerf.scala
@@ -12,9 +12,9 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config._
 import org.chipsalliance.diplomacy.lazymodule.LazyModule
-import radiance.cluster.SoftResetFinishNode
-import radiance.memory.{connectOne, idleMaster}
-import radiance.muon.MuonTileParams
+import radiance.cluster._
+import radiance.memory._
+import radiance.muon._
 import radiance.subsystem.{MuonTileAttachParams, MuonTileLike}
 
 class WithMemPerfMuonTileReplacement(
@@ -82,30 +82,111 @@ class MemPerfMuonTile(
 
   val muonParams: MuonTileParams = memMuonParams.m
 
+  val testType = "dmem"
   val reqSourceBits = 4
   val reqsPerPattern = 4096
 
-  private val patterns = TrafficPatterns.smemPatterns(muonParams.clusterId)
+  private val patterns = testType match {
+    case "smem" => TrafficPatterns.smemPatterns(muonParams.clusterId)
+    case "dmem" => TrafficPatterns.dmemPatterns(muonParams.clusterId)
+    case _ => throw new IllegalArgumentException(s"Unknown test type: $testType")
+  }
 
   val trafficGenerators = Seq.tabulate(muonParams.core.numLanes) { lane =>
     val lanePatterns = patterns.map { case (name, pattern) =>
       (name, pattern(_, lane))
     }
     LazyModule(new TLTrafficGen(
-      nodeName = s"smem_$lane",
+      nodeName = s"${testType}_$lane",
       sourceBits = reqSourceBits,
       n = reqsPerPattern,
       patterns = lanePatterns,
-    )).suggestName(s"traffic_smem_$lane")
+    )).suggestName(s"traffic_${testType}_$lane")
   }
 
-  val smemNodes: Seq[TLNode] = trafficGenerators
-    .map(x => connectOne(x.node, TLEphemeralNode.apply)(p, false))
   val icacheNode: TLNode = idleMaster()
-  val dcacheNode: TLNode = visibilityNode
   val softResetFinishSlave = SoftResetFinishNode.Slave()
 
-  visibilityNode := idleMaster(sourceBits = 6)
+  // Define smemNodes and dcacheNode based on testType
+  val (smemNodes: Seq[TLNode], dcacheNode: TLNode) = if (testType == "smem") {
+    val smem = trafficGenerators.map(x => connectOne(x.node, TLEphemeralNode.apply)(p, false))
+    val dcache = visibilityNode
+    visibilityNode := idleMaster(sourceBits = 6)
+    (smem, dcache)
+  } else {
+    val lsuDerived = new LoadStoreUnitDerivedParams(p, muonParams.core)
+    val lsuSourceIdBits = lsuDerived.sourceIdBits
+    val coalescedReqWidth = muonParams.core.numLanes * muonParams.core.archLen / 8
+
+    // Traffic generator nodes (replacing innerLsuNodes from MuonTile)
+    val trafficGenNodes = trafficGenerators.map { gen =>
+      (TLBuffer()
+        := TLSourceShrinker(1 << muonParams.core.logGMEMInFlights)
+        := gen.node)
+    }
+
+    // Coalescer setup (from MuonTile)
+    val coalescer = LazyModule(new CoalescingUnit(CoalescerConfig(
+      enable = true,
+      numLanes = muonParams.core.numLanes,
+      addressWidth = muonParams.core.archLen,
+      dataBusWidth = log2Ceil(coalescedReqWidth),
+      coalLogSize = log2Ceil(coalescedReqWidth),
+      wordSizeInBytes = muonParams.core.archLen / 8,
+      numOldSrcIds = 1 << lsuSourceIdBits,
+      numNewSrcIds = 1 << muonParams.core.logCoalGMEMInFlights,
+      respQueueDepth = 4,
+      numCoalReqs = 1,
+    )))
+
+    // L0D cache setup (from MuonTile)
+    val (l0dOut, l0dIn, l0dFlushRegNode) = muonParams.dcache.map { l0dParams =>
+      require(muonParams.dcache.map(_.blockBytes).getOrElse(coalescedReqWidth) == coalescedReqWidth)
+      val l0d = LazyModule(new TLULNBDCache(TLNBDCacheParams(
+        id = tileId,
+        cache = l0dParams,
+        cacheTagBits = muonParams.core.l0dReqTagBits,
+        flushAddr = None,  // Disable flush register to avoid unconnected node
+      ))(
+        // Add the TileVisibilityNodeKey to Parameters
+        p.alterMap(Map(
+          TileVisibilityNodeKey -> visibilityNode
+        ))
+      ))
+      // Note: No flush node created since flushAddr = None
+      (l0d.outNode, l0d.inNode, None)
+    }.getOrElse {
+      val passthru = TLEphemeralNode()
+      (passthru, passthru, None)
+    }
+
+    // Connect dcache to L0D output (from MuonTile)
+    val dcache = visibilityNode
+    dcache :=
+      ResponseFIFOFixer() :=
+      TLFragmenter(muonParams.l1CacheLineBytes, coalescedReqWidth, alwaysMin = true) :=
+      TLWidthWidget(coalescedReqWidth) :=
+      l0dOut
+
+    // Coalescer crossbar setup (from MuonTile)
+    val coalXbar = LazyModule(new TLXbar).suggestName("coal_out_agg_xbar").node
+    val nonCoalXbar = LazyModule(new TLXbar).suggestName("coal_out_nc_xbar").node
+    l0dIn := coalXbar
+
+    coalXbar := coalescer.nexusNode
+    coalescer.passthroughNodes.foreach(nonCoalXbar := _)
+    (coalXbar
+      := TLWidthWidget(muonParams.core.archLen / 8)
+      := TLSourceShrinker(1 << muonParams.core.logNonCoalGMEMInFlights)
+      := nonCoalXbar)
+
+    // Connect traffic generators to coalescer (replacing lsuNodes.foreach)
+    trafficGenNodes.foreach(coalescer.nexusNode := _)
+
+    // Return smem (idle masters) and dcache nodes
+    val smem = Seq.fill(muonParams.core.lsu.numLsuLanes)(idleMaster())
+    (smem, dcache)
+  }
 
   lazy val module = new BaseTileModuleImp[MemPerfMuonTile](this) {
 
@@ -115,9 +196,8 @@ class MemPerfMuonTile(
     outer.trafficGenerators.foreach(_.module.io.start := allLanesFinished)
 
     val allPatternsDone = VecInit(outer.trafficGenerators.map(_.module.io.allFinished)).asUInt.andR
-    outer.softResetFinishSlave.in.head._1.finished := RegNext(allPatternsDone)
-
-    val finishPulse = allLanesFinished && !RegNext(allLanesFinished) // shouldn't be necessary
+    
+    val finishPulse = allLanesFinished && !RegNext(allLanesFinished)
     val patternCount = Counter(finishPulse, patterns.length)._1
     val allFinishPulse = WireInit(false.B)
     outer.softResetFinishSlave.in.head._1.finished := RegEnable(true.B, false.B, allFinishPulse)

--- a/src/main/scala/radiance/unittest/TLTrafficGen.scala
+++ b/src/main/scala/radiance/unittest/TLTrafficGen.scala
@@ -66,7 +66,7 @@ class TLTrafficGen(val nodeName: String, val sourceBits: Int,
 }
 
 class TLTrafficGenImp(outer: TLTrafficGen) extends LazyModuleImp(outer) {
-  val verificationMode = true
+  val verificationMode = false // always ready
 
   // elaboration time
   // ================

--- a/src/main/scala/radiance/unittest/TrafficPatterns.scala
+++ b/src/main/scala/radiance/unittest/TrafficPatterns.scala
@@ -1,6 +1,7 @@
 package radiance.unittest
 
 import scala.util.Random
+import freechips.rocketchip.resources.BigIntHexContext 
 
 abstract class TrafficPattern {
   val name: String = "pattern"
@@ -12,14 +13,16 @@ abstract class TrafficPattern {
 
   def offset(time: Int, index: Int): Int
 
-  def apply(baseAddr: Int, time: Int, index: Int): ScalaTLA = {
+  def apply(baseAddr: BigInt, time: Int, index: Int): ScalaTLA = {
     require(reqSize <= busSize)
     val addr = baseAddr + offset(time, index)
+    // Align address to request size (reqSize), not just busSize
+    val alignedAddr = (addr / reqSize) * reqSize
     new ScalaTLA(
-      address = (addr / busSize) * busSize,
+      address = alignedAddr,
       lgSize = lgSize,
       data = None,
-      mask = Some(((1 << reqSize) - 1) << (addr % busSize))
+      mask = Some(((1 << reqSize) - 1) << (alignedAddr % busSize).intValue)
     )
   }
 
@@ -30,6 +33,16 @@ abstract class TrafficPattern {
   def putSmem(clusterId: Int): (Int, Int) => ScalaTLA = {
     case (x, y) =>
       val getReq = getSmem(clusterId)(x, y)
+      getReq.copy(data = Some(getReq.address))
+  }
+
+  def getDmem(clusterId: Int): (Int, Int) => ScalaTLA = {
+    this(0x100_0000 * clusterId, _, _)
+  }
+
+  def putDmem(clusterId: Int): (Int, Int) => ScalaTLA = {
+    case (x, y) =>
+      val getReq = getDmem(clusterId)(x, y)
       getReq.copy(data = Some(getReq.address))
   }
 }
@@ -141,25 +154,6 @@ object TrafficPatterns {
     Seq(0, 1).map(new RandomAccess(0, 131072 >> lgSize, _))
   }
 
-  // def smemPatterns(clusterId: Int, size: Int = 128 << 10) = {
-  //   Seq(("w", (x: TrafficPattern) => x.putSmem _),
-  //     ("r", (x: TrafficPattern) => x.getSmem _))
-  //     .flatMap { case (suffix, func) =>
-
-  //     Seq(
-  //       stridedPatterns,
-  //       randomPatterns,
-  //       tiledPatterns,
-  //       tiledPatterns.map(Transposed(_)),
-  //       swizzledPatterns,
-  //       swizzledPatterns.map(Transposed(_)),
-  //     )
-  //       .flatten
-  //       .map(Bounded(_, size))
-  //       .map(x => (s"${x.name}_$suffix", func(x)(clusterId)))
-  //   }
-  // }
-
   def smemPatterns(clusterId: Int, size: Int = 128 << 10) = {
     Seq(
       stridedPatterns,
@@ -174,6 +168,25 @@ object TrafficPatterns {
       .flatMap(x =>
         Seq(("w", (x: TrafficPattern) => x.putSmem _),
             ("r", (x: TrafficPattern) => x.getSmem _)).map { case (suffix, func) =>
+          (s"${x.name}_$suffix", func(x)(clusterId))
+        }
+      )
+  }
+
+  def dmemPatterns(clusterId: Int, size: Int = 1 << 20) = {
+    Seq(
+      stridedPatterns,
+      randomPatterns,
+      tiledPatterns,
+      tiledPatterns.map(Transposed(_)),
+      swizzledPatterns,
+      swizzledPatterns.map(Transposed(_)),
+    )
+      .flatten
+      .map(Bounded(_, size))
+      .flatMap(x =>
+        Seq(("w", (x: TrafficPattern) => x.putDmem _),
+            ("r", (x: TrafficPattern) => x.getDmem _)).map { case (suffix, func) =>
           (s"${x.name}_$suffix", func(x)(clusterId))
         }
       )

--- a/src/main/scala/radiance/unittest/TrafficPatterns.scala
+++ b/src/main/scala/radiance/unittest/TrafficPatterns.scala
@@ -16,13 +16,11 @@ abstract class TrafficPattern {
   def apply(baseAddr: BigInt, time: Int, index: Int): ScalaTLA = {
     require(reqSize <= busSize)
     val addr = baseAddr + offset(time, index)
-    // Align address to request size (reqSize), not just busSize
-    val alignedAddr = (addr / reqSize) * reqSize
     new ScalaTLA(
-      address = alignedAddr,
+      address = (addr / busSize) * busSize,
       lgSize = lgSize,
       data = None,
-      mask = Some(((1 << reqSize) - 1) << (alignedAddr % busSize).intValue)
+      mask = Some(((1 << reqSize) - 1) << (addr % busSize).intValue)
     )
   }
 
@@ -33,11 +31,11 @@ abstract class TrafficPattern {
   def putSmem(clusterId: Int): (Int, Int) => ScalaTLA = {
     case (x, y) =>
       val getReq = getSmem(clusterId)(x, y)
-      getReq.copy(data = Some(getReq.address))
+      getReq.copy(data = Some(getReq.address)) 
   }
 
   def getDmem(clusterId: Int): (Int, Int) => ScalaTLA = {
-    this(0x100_0000 * clusterId, _, _)
+    this(0x100_0000 + 0x100_0000 * clusterId, _, _)
   }
 
   def putDmem(clusterId: Int): (Int, Int) => ScalaTLA = {


### PR DESCRIPTION
- Implements memory performance testing for dmem path using a traffic generator-based test harness.
- Integrates with existing memory hierarchy (coalescer, L0D cache).
- Added D-channel buffering to resolve assertion failures in the caches when verification mode applies random backpressure on response channels.